### PR TITLE
Validation error message and other breaking API improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,6 +60,7 @@ lazy val `partial-renderer` =
     .dependsOn(core)
     .settings(
       sjsCrossTarget,
+      addScalajsReactModule("extra-ext-monocle3"),
       libraryDependencies += "dev.optics" %%% "monocle-macro" % "3.2.0",
       libraryDependencies += "org.scalameta" %%% "munit" % "0.7.29" % Test,
       testFrameworks += new TestFramework("munit.Framework")

--- a/partial-renderer/src/main/scala/io/github/nafg/scalajs/react/util/partialrenderer/PartialRenderer.scala
+++ b/partial-renderer/src/main/scala/io/github/nafg/scalajs/react/util/partialrenderer/PartialRenderer.scala
@@ -6,77 +6,70 @@ import cats.kernel.Semigroup
 import monocle.{Iso, Lens}
 
 
-trait PartialRenderer[-Props, Partial, Full, +Out] { outer =>
-  def partialityType: PartialityType[Partial, Full]
+abstract class PartialRenderer[-Props, Partial, Full, +Out](implicit val partialityType: PartialityType[Partial, Full]
+                                                           ) { self =>
+
   def render(props: Props, in: PartialSettable[Partial, Full]): Out
 
-  def xmapPartial[P1](iso: Iso[P1, Partial]): PartialRenderer[Props, P1, Full, Out] =
-    new PartialRenderer[Props, P1, Full, Out] {
-      override val partialityType = outer.partialityType.xmapPartial(iso)
-      override def render(props: Props, settable: PartialSettable[P1, Full]) =
-        outer.render(props, settable.xmapPartial(iso))
+  private def modSettable[P1, F1](f: PartialSettable[P1, F1] => PartialSettable[Partial, Full])
+                                 (implicit partialityType2: PartialityType[P1, F1]) =
+    new PartialRenderer[Props, P1, F1, Out] {
+      override def render(props: Props, settable: PartialSettable[P1, F1]) =
+        self.render(props, f(settable))
     }
 
+  def xmapPartial[P1](iso: Iso[P1, Partial]): PartialRenderer[Props, P1, Full, Out] =
+    modSettable[P1, Full](_.xmapPartial(iso))(partialityType.xmapPartial(iso))
+
   def xmapFull[F1](iso: Iso[F1, Full]): PartialRenderer[Props, Partial, F1, Out] =
-    new PartialRenderer[Props, Partial, F1, Out] {
-      override val partialityType = outer.partialityType.xmapFull(iso)
-      override def render(props: Props, settable: PartialSettable[Partial, F1]) =
-        outer.render(props, settable.xmapFull(iso))
-    }
+    modSettable[Partial, F1](_.xmapFull(iso))(partialityType.xmapFull(iso))
 
   def xmapBoth[P1, F1](isoPartial: Iso[P1, Partial], isoFull: Iso[F1, Full]): PartialRenderer[Props, P1, F1, Out] =
     xmapPartial(isoPartial).xmapFull(isoFull)
 
+  def unzoomFull[F1](get: F1 => Full)
+                    (set: Full => F1 => F1)
+                    (implicit partialityType2: PartialityType[Partial, F1]): PartialRenderer[Props, Partial, F1, Out] =
+    modSettable[Partial, F1](_.zoom(Iso.id[Partial], Lens(get)(set)))
+
+  def unzoom[P1, F1](lens: Lens[Tentative[P1, F1], Tentative[Partial, Full]])
+                    (implicit partialityType2: PartialityType[P1, F1]): PartialRenderer[Props, P1, F1, Out] =
+    modSettable[P1, F1](_.zoom(lens))
+
   def andThen[Out2](f: PartialSettable[Partial, Full] => Out => Out2) =
     new PartialRenderer[Props, Partial, Full, Out2] {
-      override def partialityType = outer.partialityType
       override def render(props: Props, settable: PartialSettable[Partial, Full]) =
-        f(settable)(outer.render(props, settable))
+        f(settable)(self.render(props, settable))
     }
 
   def mapOut[Out2](f: Out => Out2): PartialRenderer[Props, Partial, Full, Out2] = andThen(_ => f)
 
-  def zip[Props2 <: Props, P2, F2, O2 >: Out : Semigroup](that: PartialRenderer[Props2, P2, F2, O2]): PartialRenderer[
+  def zip[Props2 <: Props, P2, F2, O2 >: Out : Semigroup](other: PartialRenderer[Props2, P2, F2, O2]): PartialRenderer[
     Props2,
     (Partial, P2),
     (Full, F2),
     O2
-  ] =
-    new PartialRenderer[Props2, (Partial, P2), (Full, F2), O2] {
-      override val partialityType = outer.partialityType.zip(that.partialityType)
+  ] = {
+    val zippedPartialityType = self.partialityType.zip(other.partialityType)
+    new PartialRenderer[Props2, (Partial, P2), (Full, F2), O2]()(zippedPartialityType) {
       override def render(props: Props2, settable: PartialSettable[(Partial, P2), (Full, F2)]) = {
-        val (settable1, settable2) = PartialSettable.unzip(settable)(outer.partialityType, that.partialityType)
+        val (thisSettable, thatSettable) =
+          PartialSettable.unzip(settable)(self.partialityType, other.partialityType)
         Semigroup[O2].combine(
-          outer.render(props, settable1),
-          that.render(props, settable2)
+          self.render(props, thisSettable),
+          other.render(props, thatSettable)
         )
       }
     }
-
-  def unzoomFull[F1](pt1: PartialityType[Partial, F1])
-                    (get: F1 => Full)
-                    (set: Full => F1 => F1): PartialRenderer[Props, Partial, F1, Out] =
-    new PartialRenderer[Props, Partial, F1, Out] {
-      override def partialityType = pt1
-      override def render(props: Props, settable: PartialSettable[Partial, F1]) =
-        outer.render(props, settable.zoom(outer.partialityType)(Iso.id[Partial], Lens(get)(set)))
-    }
-
-  def unzoomEither[P1, F1](pt1: PartialityType[P1, F1])
-                          (lens: Lens[Either[P1, F1], Either[Partial, Full]]): PartialRenderer[Props, P1, F1, Out] =
-    new PartialRenderer[Props, P1, F1, Out] {
-      override def partialityType = pt1
-      override def render(props: Props, settable: PartialSettable[P1, F1]) =
-        outer.render(props, settable.zoomEither(outer.partialityType)(lens))
-    }
+  }
 }
 
 object PartialRenderer {
   type Vdom[-Props, P, F] = PartialRenderer[Props, P, F, VdomNode]
+
   def noProps[Partial, Full, Out](pt: PartialityType[Partial, Full])
                                  (renderF: PartialSettable[Partial, Full] => Out) =
-    new PartialRenderer[Any, Partial, Full, Out] {
-      override def partialityType = pt
+    new PartialRenderer[Any, Partial, Full, Out]()(pt) {
       override def render(props: Any, settable: PartialSettable[Partial, Full]) = renderF(settable)
     }
 }

--- a/partial-renderer/src/main/scala/io/github/nafg/scalajs/react/util/partialrenderer/Settable.scala
+++ b/partial-renderer/src/main/scala/io/github/nafg/scalajs/react/util/partialrenderer/Settable.scala
@@ -1,0 +1,19 @@
+package io.github.nafg.scalajs.react.util.partialrenderer
+
+import japgolly.scalajs.react.Callback
+import io.github.nafg.scalajs.react.util.SnapshotUtils.Snapshot
+
+import monocle.Lens
+
+
+case class Settable[A](value: A)(val modify: (A => A) => Callback) {
+  def set(a: A) = modify(_ => a)
+  def toStateSnapshot = Snapshot(value)(set)
+
+  def zoom[B](lens: Lens[A, B]): Settable[B] =
+    Settable(lens.get(value))(f => modify(lens.modify(f)))
+  def zoom[B](get: A => B)(set: B => A => A): Settable[B] =
+    Settable(get(value))(f => modify(a => set(f(get(a)))(a)))
+  def xmap[B](get: A => B)(reverseGet: B => A): Settable[B] =
+    Settable(get(value))(f => modify(a => reverseGet(f(get(a)))))
+}

--- a/partial-renderer/src/main/scala/io/github/nafg/scalajs/react/util/partialrenderer/Tentative.scala
+++ b/partial-renderer/src/main/scala/io/github/nafg/scalajs/react/util/partialrenderer/Tentative.scala
@@ -1,0 +1,66 @@
+package io.github.nafg.scalajs.react.util.partialrenderer
+
+import monocle.{Iso, Lens}
+
+
+sealed trait Tentative[+P, +F] {
+  def error: Option[String]
+  def mapFull[F1 >: F, F2](f: F1 => F2): Tentative[P, F2]
+  def mapPartial[P1 >: P, P2](f: P1 => P2): Tentative[P2, F]
+  def fold[A](onPartial: P => A, onFull: F => A): A
+  def partialValue[P1 >: P, F1 >: F](implicit partialityType: PartialityType[P1, F1]): P1
+}
+
+object Tentative {
+  case class Partial[+P](partial: P, override val error: Option[String] = None) extends Tentative[P, Nothing] {
+    override def toString = s"Tentative.Partial($partial, $error)"
+    override def mapPartial[P1 >: P, P2](f: P1 => P2) = Partial(f(partial), error)
+    override def mapFull[F1 >: Nothing, F2](f: F1 => F2) = this
+    override def fold[A](onPartial: P => A, onFull: Nothing => A) = onPartial(partial)
+    override def partialValue[P1 >: P, F1 >: Nothing](implicit partialityType: PartialityType[P1, F1]): P1 = partial
+  }
+
+  case class Full[+F](full: F) extends Tentative[Nothing, F] {
+    override def toString = s"Tentative.Full($full)"
+    override def error: Option[String] = None
+    override def mapPartial[P1 >: Nothing, P2](f: P1 => P2) = this
+    override def mapFull[F1 >: F, F2](f: F1 => F2) = Full(f(full))
+    override def fold[A](onPartial: Nothing => A, onFull: F => A) = onFull(full)
+    override def partialValue[P1 >: Nothing, F1 >: F](implicit partialityType: PartialityType[P1, F1]): P1 =
+      partialityType.fullToPartial(full)
+  }
+
+  def fromOption[P, F](option: Option[F], partial: => P): Tentative[P, F] =
+    option.fold[Tentative[P, F]](Partial(partial))(Full(_))
+
+  def apply[P, F](partial: P)(implicit partialityType: PartialityType[P, F]): Tentative[P, F] =
+    partialityType.partialToFull(partial) match {
+      case Right(full) => Full(full)
+      case Left(error) => Partial(partial, Some(error))
+    }
+
+  def default[P, F](implicit partialityType: PartialityType[P, F]): Tentative[P, F] =
+    Tentative(partialityType.default)
+
+  def isoTentativePartialValue[P, F](implicit partialityType: PartialityType[P, F]) =
+    Iso[Tentative[P, F], P](_.partialValue)(Tentative(_))
+
+  def lensTentative[P1, F1, P2, F2](lensPartial: Lens[P1, P2], lensFull: Lens[F1, F2])
+                                   (implicit partialityTypeOuter: PartialityType[P1, F1],
+                                    partialityTypeInner: PartialityType[P2, F2]
+                                   ): Lens[Tentative[P1, F1], Tentative[P2, F2]] = {
+    def replace(partialOuter: P1, partialInner: P2) =
+      Tentative(lensPartial.replace(partialInner)(partialOuter))
+
+    Lens[Tentative[P1, F1], Tentative[P2, F2]](_.mapPartial(lensPartial.get).mapFull(lensFull.get)) {
+      case Full(fullInner)          => {
+        case Full(fullOuter)          => Full(lensFull.replace(fullInner)(fullOuter))
+        case Partial(partialOuter, _) => replace(partialOuter, partialityTypeInner.fullToPartial(fullInner))
+      }
+      case Partial(partialInner, _) => {
+        case Partial(p1, _) => replace(p1, partialInner)
+        case Full(f)        => replace(partialityTypeOuter.fullToPartial(f), partialInner)
+      }
+    }
+  }
+}

--- a/partial-renderer/src/test/scala/io/github/nafg/scalajs/react/util/partialrenderer/PartialSettableTests.scala
+++ b/partial-renderer/src/test/scala/io/github/nafg/scalajs/react/util/partialrenderer/PartialSettableTests.scala
@@ -4,41 +4,50 @@ import japgolly.scalajs.react.Callback
 
 
 class PartialSettableTests extends munit.FunSuite {
-  class VarSnapshot[A](init: A) {
-    var value = init
-    def settable[F](pt: PartialityType[A, F]) =
-      PartialSettable(pt, Left(value))(f => Callback(this.value = pt.eitherToPartial(f(Left(this.value)))))
+  class VarSnapshot[P, F](implicit partialityType: PartialityType[P, F]) {
+    var value: Tentative[P, F] = Tentative.Partial(partialityType.default)
+
+    def settable =
+      PartialSettable[P, F](value) { f =>
+        Callback {
+          value = f(value)
+        }
+      }
   }
 
   test("PartialSettable.unzip") {
-    val varSnapshot = new VarSnapshot((Option.empty[Int], Option.empty[String]))
     val stateB = PartialityType.option[Int]
     val stateC = PartialityType.option[String]
-    val a = varSnapshot.settable(stateB.zip(stateC))
+
+    val partialityType = stateB.zip(stateC)
+    val varSnapshot    = new VarSnapshot()(partialityType)
+
+    val a: PartialSettable[(Option[Int], Option[String]), (Int, String)] =
+      varSnapshot.settable
 
     a.setFullCB((10, "abc")).runNow()
-    assertEquals(varSnapshot.value, (Some(10), Some("abc")))
+    assertEquals(varSnapshot.value, Tentative.Full((10, "abc")))
 
     a.setPartialCB((None, None)).runNow()
-    assertEquals(varSnapshot.value, (None, None))
+    assertEquals(varSnapshot.value, Tentative.Partial((None, None), Some("Value is empty")))
 
     a.setPartialCB((Some(15), None)).runNow()
-    assertEquals(varSnapshot.value, (Some(15), None))
+    assertEquals(varSnapshot.value, Tentative.Partial((Some(15), None), Some("Value is empty")))
 
     a.setPartialCB((None, Some("def"))).runNow()
-    assertEquals(varSnapshot.value, (None, Some("def")))
+    assertEquals(varSnapshot.value, Tentative.Partial((None, Some("def")), Some("Value is empty")))
 
     a.setPartialCB((Some(20), Some("xyz"))).runNow()
-    assertEquals(varSnapshot.value, (Some(20), Some("xyz")))
+    assertEquals(varSnapshot.value, Tentative.Full((20, "xyz")))
 
     val unzipped = PartialSettable.unzip(a)(stateB, stateC)
 
     a.setPartialCB((None, None)).runNow()
 
     unzipped._1.setPartialCB(Some(1)).runNow()
-    assertEquals(varSnapshot.value, (Some(1), None))
+    assertEquals(varSnapshot.value, Tentative.Partial((Some(1), None), Some("Value is empty")))
 
     unzipped._2.setPartialCB(Some("a")).runNow()
-    assertEquals(varSnapshot.value, (Some(1), Some("a")))
+    assertEquals(varSnapshot.value, Tentative.Full((1, "a")))
   }
 }

--- a/partial-renderer/src/test/scala/io/github/nafg/scalajs/react/util/partialrenderer/PartialityTypeTests.scala
+++ b/partial-renderer/src/test/scala/io/github/nafg/scalajs/react/util/partialrenderer/PartialityTypeTests.scala
@@ -27,9 +27,9 @@ class PartialityTypeTests extends munit.FunSuite {
 
     assertEquals(a.default, (None, None))
     assertEquals(a.fullToPartial((1, 2)), (Some(1), Some(2)))
-    assertEquals(a.partialToFull((Some(1), Some(2))), Some((1, 2)))
-    assertEquals(a.partialToFull((None, Some(2))), None)
-    assertEquals(a.partialToFull((Some(1), None)), None)
+    assertEquals(a.partialToFull((Some(1), Some(2))), Right((1, 2)))
+    assert(a.partialToFull((None, Some(2))).isLeft)
+    assert(a.partialToFull((Some(1), None)).isLeft)
   }
 
   test("PartialStateType#xmapFull") {
@@ -39,15 +39,15 @@ class PartialityTypeTests extends munit.FunSuite {
     assertEquals(b.default, false)
     assertEquals(b.fullToPartial(Some(())), true)
     assertEquals(b.fullToPartial(None), false)
-    assertEquals(b.partialToFull(true), Some(Some(())))
-    assertEquals(b.partialToFull(false), Some(None))
+    assertEquals(b.partialToFull(true), Right(Some(())))
+    assertEquals(b.partialToFull(false), Right(None))
 
-    val c = PartialityType("")(s => Try(s.toInt).toOption)(_.toString)
+    val c = PartialityType("")(s => Try(s.toInt).toEither.left.map(_.toString))(_.toString)
     val d = c.xmapFull(Iso[Integer, Int](_.intValue)(Integer.valueOf))
 
     assertEquals(d.default, "")
     assertEquals(d.fullToPartial(1), "1")
-    assertEquals(d.partialToFull("1"), Some[Integer](1))
-    assertEquals(d.partialToFull("a"), None)
+    assertEquals(d.partialToFull("1"), Right(1: Integer))
+    assert(d.partialToFull("a").isLeft)
   }
 }


### PR DESCRIPTION
1. Tentative ADT instead of Either[Partial, Full]
2. Tentative.Partial stores an optional validation error message
3. PartialityType is passed implicitly
4. Generalized Settable