### PR TITLE
Rename PublicBroadcaster#{broadcast->publish}

### DIFF
--- a/core/src/main/scala/io/github/nafg/scalajs/react/util/Messages.scala
+++ b/core/src/main/scala/io/github/nafg/scalajs/react/util/Messages.scala
@@ -14,7 +14,7 @@ class Messages {
   private object broadcaster extends PublicBroadcaster[Message]
 
   def post(timeout: Double = 1000)(content: TagMod*): Unit =
-    broadcaster.broadcast(Message(timeout, content.toTagMod)).runNow()
+    broadcaster.publish(Message(timeout, content.toTagMod)).runNow()
   def postCB(timeout: Double = 1000)(content: TagMod*) = Callback {
     post(timeout)(content *)
   }

--- a/core/src/main/scala/io/github/nafg/scalajs/react/util/PublicBroadcaster.scala
+++ b/core/src/main/scala/io/github/nafg/scalajs/react/util/PublicBroadcaster.scala
@@ -3,7 +3,16 @@ package io.github.nafg.scalajs.react.util
 import japgolly.scalajs.react.extra.Broadcaster
 
 
+/**
+ * Allows publishing a message from outside the class.
+ *
+ * `Broadcaster#broacast` is `protected` so it can only be called from within.
+ *
+ * Due to https://github.com/scala/bug/issues/12809, we can't override `broadcast`
+ * so this trait adds a public alternative called `publish` instead.
+ *
+ * @tparam A The type of messages that can be broadcasted.
+ */
 trait PublicBroadcaster[A] extends Broadcaster[A] {
-  // overriding to make it public
-  override def broadcast(a: A) = super.broadcast(a)
+  def publish(a: A) = broadcast(a)
 }


### PR DESCRIPTION
Workaround for https://github.com/scala/bug/issues/12809
