### PR TITLE
feat(partialrenderer): add useSettable custom hook for local state management

### DIFF
--- a/partial-renderer/src/main/scala/io/github/nafg/scalajs/react/util/partialrenderer/Settable.scala
+++ b/partial-renderer/src/main/scala/io/github/nafg/scalajs/react/util/partialrenderer/Settable.scala
@@ -1,7 +1,7 @@
 package io.github.nafg.scalajs.react.util.partialrenderer
 
 import japgolly.scalajs.react.extra.StateSnapshot
-import japgolly.scalajs.react.{Callback, StateAccessor}
+import japgolly.scalajs.react.{Callback, CustomHook, StateAccessor}
 import io.github.nafg.scalajs.react.util.SnapshotUtils.Snapshot
 
 import monocle.Lens
@@ -23,4 +23,9 @@ object Settable                                                    {
     Settable(state.value)(state.modState)
   def of[I, S](i: I)(implicit t: StateAccessor.ReadImpureWritePure[I, S]): Settable[S] =
     Settable(t.state(i))(f => t(i).modState(f))
+
+  def useSettable[A](initial: => A): CustomHook[Unit, Settable[A]] =
+    CustomHook[Unit]
+      .useReducerBy[A, A => A](reducer = _ => (state, modify) => modify(state), initialState = _ => initial)
+      .buildReturning((_, reducer) => Settable(reducer.value)(reducer.dispatch))
 }


### PR DESCRIPTION
Introduced the useSettable custom hook in Settable.scala to provide a convenient
way to manage local state within Scala.js React components. This hook uses
useReducerBy internally to maintain state and expose a Settable instance,
allowing components to easily read and modify state with a consistent API.
This addition enhances the library by simplifying state handling patterns
and aligns with React's hooks paradigm.
