### PR TITLE
feat(partialrenderer): add withDefaultAsNone to handle Option[Full] defaults

### DIFF
--- a/partial-renderer/src/main/scala/io/github/nafg/scalajs/react/util/partialrenderer/PartialityType.scala
+++ b/partial-renderer/src/main/scala/io/github/nafg/scalajs/react/util/partialrenderer/PartialityType.scala
@@ -34,6 +34,12 @@ case class PartialityType[Partial, Full](
     } { case (f1, f2) =>
       (this.fullToPartial(f1), that.fullToPartial(f2))
     }
+
+  def withDefaultAsNone: PartialityType[Partial, Option[Full]] =
+    PartialityType[Partial, Option[Full]](default) {
+      case `default` => Right(None)
+      case other     => partialToFull(other).map(Some(_))
+    }(_.fold(default)(fullToPartial))
 }
 object PartialityType {
   def apply[Partial, Full](default: Partial)(


### PR DESCRIPTION
Introduced the withDefaultAsNone method in PartialityType to support cases where
Full values are wrapped in Option, treating the default Partial value as None.
This allows seamless conversion between Partial and Option[Full], improving
flexibility when dealing with optional full values in partial rendering scenarios.
